### PR TITLE
Improve YouTube storyboard display

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -324,7 +324,7 @@ class vttThumbnailsPlugin {
     return {
       x: splitCoords[0],
       y: splitCoords[1],
-      w: splitCoords[2],
+      w: splitCoords[2] - 2, // youtube storyboard specific
       h: splitCoords[3],
       image: imageUrl
     }


### PR DESCRIPTION
YouTube storyboard sprites include a 2 pixels wide strip of random data, so this reduces the width by 2px.